### PR TITLE
Fixed Windows build issues and made it independent on system wide installs

### DIFF
--- a/.github/workflows/ccpp.yaml
+++ b/.github/workflows/ccpp.yaml
@@ -13,10 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: install hts_engine_API
-      run: |
-        git clone https://github.com/r9y9/hts_engine_API
-        cd hts_engine_API/src && mkdir -p build && cd build && cmake .. && sudo make -j install
+      with:
+        submodules: 'true'
     - name: configure
       run: cd src && mkdir build && cd build && cmake ..
     - name: build

--- a/.github/workflows/ccpp.yaml
+++ b/.github/workflows/ccpp.yaml
@@ -8,14 +8,24 @@ on:
 
 jobs:
   build-ubuntu:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
     - name: configure
       run: cd src && mkdir build && cd build && cmake ..
+    - name: build
+      run:  cd src/build && make -j
+  build-windows:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - name: install mingw
+      run: apt update && apt install -y mingw-w64    
+    - name: configure
+      run: cd src && mkdir build && cd build && CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ cmake -DCMAKE_SYSTEM_NAME=Windows ..
     - name: build
       run:  cd src/build && make -j

--- a/.github/workflows/ccpp.yaml
+++ b/.github/workflows/ccpp.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         submodules: 'true'
     - name: install mingw
-      run: apt update && apt install -y mingw-w64    
+      run: sudo apt update && sudo apt install -y mingw-w64    
     - name: configure
       run: cd src && mkdir build && cd build && CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ cmake -DCMAKE_SYSTEM_NAME=Windows ..
     - name: build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/hts_engine_api/hts_engine"]
+	path = src/lib/hts_engine_API/hts_engine
+	url = git@github.com:r9y9/hts_engine_API.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,12 +16,8 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 
 # find HTSEngine
 # adapted from https://github.com/r9y9/open_jtalk/blob/1.10/src/CMakeLists.txt
-find_path(HTS_ENGINE_INCLUDE_DIR HTS_engine.h)
-find_library(HTS_ENGINE_LIB hts_engine_API)
-if(NOT HTS_ENGINE_LIB)
-  # fallback
-  find_library(HTS_ENGINE_LIB HTSEngine)
-endif()
+
+add_subdirectory(lib/hts_engine_API/hts_engine/src)
 
 configure_file(sinsy.pc.in "${PROJECT_BINARY_DIR}/sinsy.pc" @ONLY)
 
@@ -39,6 +35,7 @@ include_directories(sinsy
   include/sinsy
   lib
   lib/converter
+  lib/hts_engine_API/hts_engine/src/include
   lib/hts_engine_API
   lib/japanese
   lib/label
@@ -47,7 +44,7 @@ include_directories(sinsy
   lib/util
   lib/xml
   ${PROJECT_BINARY_DIR} # for generated headers
-  )
+)
 
 add_library(sinsy lib/Sinsy.cpp
   ${converter_source} ${hts_engine_API_source} ${japanese_source} ${label_source}
@@ -56,17 +53,13 @@ set_target_properties(sinsy PROPERTIES
   VERSION ${PROJECT_VER}
   SOVERSION ${PROJECT_APIVER}
 )
-# link hts_engine_API and add include dir
-if(HTS_ENGINE_INCLUDE_DIR AND HTS_ENGINE_LIB)
-  target_link_libraries(sinsy ${HTS_ENGINE_LIB})
-  include_directories(sinsy ${HTS_ENGINE_INCLUDE_DIR})
-else()
-  message(FATAL_ERROR "Required HTSEngine not found")
-endif()
 
 add_executable(sinsy-bin bin/sinsy.cpp)
-target_link_libraries(sinsy-bin sinsy)
-target_link_libraries(sinsy-bin  ${HTS_ENGINE_LIB})
+
+target_link_libraries(sinsy-bin sinsy hts_engine_API)
+if (WIN32)
+target_link_libraries(sinsy-bin -static-libgcc -static-libstdc++)
+endif()
 set_target_properties(sinsy-bin PROPERTIES OUTPUT_NAME sinsy)
 
 install(TARGETS sinsy sinsy-bin DESTINATION lib RUNTIME DESTINATION bin)

--- a/src/lib/util/util_types.h
+++ b/src/lib/util/util_types.h
@@ -47,7 +47,7 @@ namespace sinsy
 
 #ifndef INT8
 #ifdef _WIN32
-typedef __int8 INT8;
+typedef char INT8;
 #elif (SIZEOF_CHAR==1)
 typedef char INT8;
 #elif (SIZEOF_SHORT==1)
@@ -65,7 +65,7 @@ typedef char INT8;
 
 #ifndef UINT8
 #ifdef _WIN32
-typedef unsigned __int8 UINT8;
+typedef unsigned char UINT8;
 #elif (SIZEOF_UNSIGNED_CHAR==1)
 typedef unsigned char UINT8;
 #elif (SIZEOF_UNSIGNED_SHORT==1)
@@ -83,7 +83,7 @@ typedef unsigned char UINT8;
 
 #ifndef INT16
 #ifdef _WIN32
-typedef __int16 INT16;
+typedef short INT16;
 #elif (SIZEOF_CHAR==2)
 typedef char INT16;
 #elif (SIZEOF_SHORT==2)
@@ -101,7 +101,7 @@ typedef short INT16;
 
 #ifndef UINT16
 #ifdef _WIN32
-typedef unsigned __int16 UINT16;
+typedef unsigned short UINT16;
 #elif (SIZEOF_UNSIGNED_CHAR==2)
 typedef unsigned char UINT16;
 #elif (SIZEOF_UNSIGNED_SHORT==2)
@@ -119,7 +119,7 @@ typedef unsigned short UINT16;
 
 #ifndef INT32
 #ifdef _WIN32
-typedef __int32 INT32;
+typedef int INT32;
 #elif (SIZEOF_CHAR==4)
 typedef char INT32;
 #elif (SIZEOF_SHORT==4)
@@ -137,7 +137,7 @@ typedef int INT32;
 
 #ifndef UINT32
 #ifdef _WIN32
-typedef unsigned __int32 UINT32;
+typedef unsigned int UINT32;
 #elif (SIZEOF_UNSIGNED_CHAR==4)
 typedef unsigned char UINT32;
 #elif (SIZEOF_UNSIGNED_SHORT==4)
@@ -155,7 +155,7 @@ typedef unsigned int UINT32;
 
 #ifndef INT64
 #ifdef _WIN32
-typedef __int64 INT64;
+typedef long INT64;
 #elif (SIZEOF_CHAR==8)
 typedef char INT64;
 #elif (SIZEOF_SHORT==8)
@@ -173,7 +173,7 @@ typedef long long INT64;
 
 #ifndef UINT64
 #ifdef _WIN32
-typedef unsigned __int64 UINT64;
+typedef unsigned long UINT64;
 #elif (SIZEOF_UNSIGNED_CHAR==8)
 typedef unsigned char UINT64;
 #elif (SIZEOF_UNSIGNED_SHORT==8)


### PR DESCRIPTION
I fixed issues preventing it to build on windows and made it so it uses hts_engine as a submodule rather than as a system wide install so that people don't need to install anything before to be able to build it on their OS